### PR TITLE
runtime: Implement various entries from the todo list

### DIFF
--- a/FNaF Studio Runtime/Data/CRScript/ScriptingAPI.cs
+++ b/FNaF Studio Runtime/Data/CRScript/ScriptingAPI.cs
@@ -3,7 +3,6 @@ using FNaFStudio_Runtime.Office;
 using FNaFStudio_Runtime.Office.Scenes;
 using FNaFStudio_Runtime.Util;
 using Raylib_CsLo;
-using static FNaFStudio_Runtime.Data.Definitions.GameJson;
 
 namespace FNaFStudio_Runtime.Data.CRScript;
 
@@ -63,6 +62,7 @@ public class ScriptingAPI
             { "change_office_state", SetOfficeState },
 
             // Animatronics
+            { "move_anim_light", MoveAnimToLight },
 
             // Cameras
             { "if_current_cam", IfCurrentCamera },
@@ -112,10 +112,18 @@ public class ScriptingAPI
         return false;
     }
 
+    public static bool MoveAnimToLight(List<string> args)
+    {
+        PathFinder.MoveAnimToNode(args[0], args[1]);
+        return true;
+    }
+
     private static bool ChangeCamera(List<string> args)
     {
         if (OfficeCore.OfficeState != null && OfficeCore.OfficeState.Cameras.ContainsKey(args[0]))
-            OfficeCore.OfficeState.Player.CurrentCamera = args[0];
+        {
+            OfficeCore.OfficeState.Player.SetCamera(args[0]);
+        }
         else
             Logger.LogFatalAsync("ScriptingAPI",
                 "OfficeState is null or invalid argument provided for Change Camera. (" + args[0] + ")");
@@ -293,8 +301,8 @@ public class ScriptingAPI
 
         return true;
     }
-    
-	private bool SetObjectPanorama(List<string> args)
+
+    private bool SetObjectPanorama(List<string> args)
     {
         if (OfficeCore.OfficeState != null && !OfficeCore.LoadingLock)
         {
@@ -308,7 +316,7 @@ public class ScriptingAPI
         }
 
         return true;
-    }    
+    }
 
     private bool HideCamSprite(List<string> args)
     {

--- a/FNaF Studio Runtime/Data/Definitions/GameJson.cs
+++ b/FNaF Studio Runtime/Data/Definitions/GameJson.cs
@@ -2,8 +2,6 @@ using FNaFStudio_Runtime.Util;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Raylib_CsLo;
-using System.IO;
-using System.Threading.Channels;
 
 namespace FNaFStudio_Runtime.Data.Definitions;
 
@@ -85,6 +83,7 @@ public class GameJson
         public int Chance { get; set; } = 0;
         public string State { get; set; } = string.Empty;
         public List<PathNode> Path { get; set; } = [];
+        public List<PathNode> AltPath { get; set; } = [];
 
         public override string ToString()
         {
@@ -326,7 +325,7 @@ public class GameJson
     public class Sounds
     {
         public string Ambience { get; set; } = string.Empty;
-        public List<string> AnimatronicMove { get; set; } = [];
+        [JsonProperty("animatronic_move")] public List<string> AnimatronicMove { get; set; } = [];
         public string Blip { get; set; } = string.Empty;
         public string Camdown { get; set; } = string.Empty;
         public string Camup { get; set; } = string.Empty;
@@ -338,7 +337,7 @@ public class GameJson
         public string MusicBoxRunOut { get; set; } = string.Empty;
         public List<string> Phone_Calls { get; set; } = [];
         public string Powerout { get; set; } = string.Empty;
-        public string SignalInterrupted { get; set; } = string.Empty;
+        [JsonProperty("signal_interrupted")] public string SignalInterrupted { get; set; } = string.Empty;
         public string Stare { get; set; } = string.Empty;
     }
 

--- a/FNaF Studio Runtime/Data/SoundPlayer.cs
+++ b/FNaF Studio Runtime/Data/SoundPlayer.cs
@@ -7,6 +7,7 @@ public class SoundPlayer
 {
     private static readonly Dictionary<string, bool> loopingSounds = [];
     private static readonly List<string> channels = new(new string[48]);
+    public static float MasterVolume = 70;
 
     public static void LoadAudioAssets(string assetsPath)
     {
@@ -33,6 +34,7 @@ public class SoundPlayer
             {
                 channels[channel] = id;
                 Raylib.PlaySound(sound);
+                Raylib.SetSoundVolume(sound, (100 / MasterVolume));
                 if (loopAudio) SetSoundLooping(id, true);
             }
             else
@@ -53,6 +55,7 @@ public class SoundPlayer
             Raylib.StopSound(sound);
             channels[channelIdx] = id;
             Raylib.PlaySound(sound);
+            Raylib.SetSoundVolume(sound, (100 / MasterVolume));
             if (loopAudio) SetSoundLooping(id, true);
         }
         else
@@ -112,7 +115,7 @@ public class SoundPlayer
         {
             if (!string.IsNullOrEmpty(channels[channelIdx]))
             {
-                Raylib.SetSoundVolume(Cache.GetSound(channels[channelIdx]), volume);
+                Raylib.SetSoundVolume(Cache.GetSound(channels[channelIdx]), (volume / MasterVolume));
             }
         }
         else
@@ -123,7 +126,7 @@ public class SoundPlayer
     {
         foreach (var id in channels)
             if (!string.IsNullOrEmpty(id))
-                Raylib.SetSoundVolume(Cache.GetSound(id), volume);
+                Raylib.SetSoundVolume(Cache.GetSound(id), (volume / MasterVolume));
 
         return;
     }

--- a/FNaF Studio Runtime/Office/Definitions/OfficeCamera.cs
+++ b/FNaF Studio Runtime/Office/Definitions/OfficeCamera.cs
@@ -1,19 +1,46 @@
-namespace FNaFStudio_Runtime.Office.Definitions;
+using FNaFStudio_Runtime.Data;
 
+namespace FNaFStudio_Runtime.Office.Definitions;
 public class OfficeCamera
 {
     public bool Panorama;
-
     public int Scroll;
-
     public string State = "Default";
-
     public Dictionary<string, string> States = [];
-
     public bool Static;
+    public bool Interrupted = false;
+    public float InterruptTimer = 0f;
 
     public void SetState(string state)
     {
         State = state;
+    }
+
+    public void SetInterrupted(bool interrupted)
+    {
+        Interrupted = interrupted;
+        if (interrupted)
+        {
+            InterruptTimer = 3.0f;
+        }
+        else
+        {
+            InterruptTimer = 0f;
+        }
+        SoundPlayer.PlayOnChannel(GameState.Project.Sounds.SignalInterrupted, false, 10);
+    }
+
+    public void Update(float deltaTime)
+    {
+        if (Interrupted && InterruptTimer > 0)
+        {
+            InterruptTimer -= deltaTime;
+            if (InterruptTimer <= 0)
+            {
+                Interrupted = false;
+                InterruptTimer = 0f;
+                SoundPlayer.StopChannel(10);
+            }
+        }
     }
 }

--- a/FNaF Studio Runtime/Office/Definitions/Player.cs
+++ b/FNaF Studio Runtime/Office/Definitions/Player.cs
@@ -1,3 +1,5 @@
+using FNaFStudio_Runtime.Data;
+
 namespace FNaFStudio_Runtime.Office.Definitions;
 
 public class Player
@@ -13,11 +15,12 @@ public class Player
 
     public bool IsMaskOn;
 
-    public bool SignalInterrupted;
+    public bool SignalInterrupted; // DEPRECATED
 
-    public static void SetCamera(Player self, string cam)
+    public void SetCamera(string cam)
     {
-        self.CurrentCamera = cam;
+        CurrentCamera = cam;
+        SoundPlayer.SetChannelVolume(10, (OfficeCore.OfficeState.Cameras[cam].Interrupted && IsCameraUp) ? 100 : 0);
     }
 
     public void Putdown()

--- a/FNaF Studio Runtime/Office/PathFinder.cs
+++ b/FNaF Studio Runtime/Office/PathFinder.cs
@@ -1,29 +1,48 @@
 ﻿using FNaFStudio_Runtime.Data;
 using FNaFStudio_Runtime.Menus;
 using FNaFStudio_Runtime.Util;
+using System.Collections.Concurrent;
 using static FNaFStudio_Runtime.Data.Definitions.GameJson;
 
-namespace FNaFStudio_Runtime.Office;
-
-public class PathFinder
+namespace FNaFStudio_Runtime.Office
 {
-    private static readonly Random Rng = new();
-    private static List<PathTask> ActiveTasks = [];
-
-    public static void TakePath(string anim, int pathIndex, List<PathNode>? path = null)
+    public class PathFinder
     {
-        if (OfficeCore.OfficeState == null) return;
+        private static readonly Random Rng = new();
+        private static List<PathTask> ActiveTasks = new();
+        private static readonly Dictionary<string, List<PathNode>> CurrentSubPaths = new();
+        private static readonly Dictionary<string, List<PathNode>> FullPaths = new();
+        private static readonly Dictionary<string, Stack<PathContext>> PathStacks = new();
+        private static ConcurrentQueue<(string Anim, string LightId)> PendingAnimQueue = new();
+        private record PathContext(List<PathNode> Path, List<PathNode> FullPath, int Index);
 
-        var animObj = GameState.Project.Animatronics[anim];
-        if (animObj.AI.Count < OfficeCore.OfficeState.Night)
-            animObj.CurAI = animObj.AI[OfficeCore.OfficeState.Night];
-        path ??= animObj.Path;
-
-        if (path != null)
+        public static void TakePath(string anim, int pathIndex, List<PathNode>? path = null, List<PathNode>? fullPath = null)
         {
+            if (OfficeCore.OfficeState == null) return;
+
+            var animObj = GameState.Project.Animatronics[anim];
+            if (animObj.AI.Count < OfficeCore.OfficeState.Night)
+                animObj.CurAI = animObj.AI[OfficeCore.OfficeState.Night];
+
+            path ??= animObj.Path;
+            fullPath ??= path;
+
+            if (!PathStacks.ContainsKey(anim))
+                PathStacks[anim] = new Stack<PathContext>();
+
             if (pathIndex >= path.Count)
             {
-                Logger.LogAsync("PathFinder", $"{anim} PATH ENDED");
+                if (PathStacks[anim].Count > 0)
+                {
+                    var parent = PathStacks[anim].Pop();
+                    Logger.LogAsync("PathFinder", $"{anim} returning to parent path at index {parent.Index + 1}");
+                    TakePath(anim, parent.Index + 1, parent.Path, parent.FullPath);
+                }
+                else
+                {
+                    Logger.LogAsync("PathFinder", $"{anim} path reset");
+                    TakePath(anim, 0, animObj.Path, animObj.Path);
+                }
                 return;
             }
 
@@ -35,176 +54,332 @@ public class PathFinder
             }
 
             animObj.PathIndex = pathIndex;
+            CurrentSubPaths[anim] = path;
+            FullPaths[anim] = fullPath;
+
+            Logger.LogAsync("PathFinder", $"{anim} moving to {newPath.Type} ({newPath.ID}) at index {pathIndex}");
             HandleMovement(animObj, newPath, anim);
             ActiveTasks.Add(new(animObj, newPath, anim));
         }
-    }
 
-    public static void Update()
-    {
-        foreach (var task in ActiveTasks.ToList())
+        public static void Update()
         {
-            if (task.AnimObj.Path[task.AnimObj.PathIndex].Type == "office") ; // TODO: stare
-            if (task.AnimObj.Paused || !task.AnimObj.Moving)
+            foreach (var task in ActiveTasks.ToList())
             {
-                if (task.AnimObj.MoveTime > 0)
-                    task.AnimObj.MoveTime--;
-                else if (task.AnimObj.AI[OfficeCore.OfficeState?.Night ?? 0] >= Rng.Next(1, 20))
-                    task.AnimObj.Moving = true;
-                else
-                    task.AnimObj.MoveTime = Rng.Next(150, 500);
-                continue;
+                var path = CurrentSubPaths[task.Anim];
+                if (task.AnimObj.Paused || !task.AnimObj.Moving)
+                {
+                    if (task.AnimObj.MoveTime > 0)
+                        task.AnimObj.MoveTime--;
+                    else if (task.AnimObj.AI[OfficeCore.OfficeState?.Night - 1 ?? 0] >= Rng.Next(1, 20))
+                        task.AnimObj.Moving = true;
+                    else
+                        task.AnimObj.MoveTime = Rng.Next(150, 500);
+                    continue;
+                }
+
+                if (GameState.Project.Sounds.AnimatronicMove.Count > 0)
+                    SoundPlayer.PlayOnChannel(GameState.Project.Sounds.AnimatronicMove[Rng.Next(GameState.Project.Sounds.AnimatronicMove.Count)], false, 11);
+                task.AnimObj.Moving = false;
+                ActiveTasks.Remove(task);
+                TakePath(task.Anim, task.AnimObj.PathIndex + 1, CurrentSubPaths[task.Anim], FullPaths[task.Anim]);
+            }
+        }
+
+        private static void HandleMovement(Animatronic animObj, PathNode newPath, string anim)
+        {
+            if (animObj.PathIndex > 0 && CurrentSubPaths.ContainsKey(anim))
+            {
+                var path = CurrentSubPaths[anim];
+                var prevPath = path[animObj.PathIndex - 1];
+                if (prevPath.Type == "light" && newPath.Type != "light")
+                {
+                    Logger.LogAsync("PathFinder", $"{anim} moved out of light node");
+                    var tempQueue = new ConcurrentQueue<(string Anim, string LightId)>();
+                    while (PendingAnimQueue.TryDequeue(out var queued))
+                    {
+                        if (queued.Anim != anim)
+                            tempQueue.Enqueue(queued);
+                    }
+                    PendingAnimQueue = tempQueue;
+                }
             }
 
-            if (GameState.Project.Sounds.AnimatronicMove.Count > 0)
-                SoundPlayer.PlayOnChannel(GameState.Project.Sounds.AnimatronicMove[Rng.Next(GameState.Project.Sounds.AnimatronicMove.Count)], false, 11);
-            task.AnimObj.Moving = false;
-            ActiveTasks.Remove(task);
-            TakePath(task.Anim, task.AnimObj.PathIndex + 1);
-        }
-    }
-
-    private static void HandleMovement(Animatronic animObj, PathNode newPath, string anim)
-    {
-        switch (newPath.Type)
-        {
-            case "camera":
-                UpdateCam(anim, animObj, newPath);
-                break;
-            case "music_box":
-                animObj.MoveTime = 1000;
-                break;
-            case "light":
-                UpdateCam(anim, animObj, newPath);
-                UpdateOffice(anim);
-                break;
-            case "door":
-                HandleDoorMovement(anim, animObj, newPath);
-                break;
-            case "office":
-                UpdateOffice(anim);
-                break;
-            case "chance":
-                if (Rng.Next(1, newPath.Chance) == 1)
-                    TakePath(anim, 0, newPath.Path);
-                break;
-            case "change_state":
-                animObj.State = newPath.State;
-                UpdateCam(anim, animObj, newPath);
-                break;
-        }
-    }
-
-    private static void HandleDoorMovement(string anim, Animatronic animObj, PathNode newPath)
-    {
-        if (OfficeCore.OfficeState != null)
-        {
-            foreach (var door in OfficeCore.OfficeState.Office.Doors)
+            switch (newPath.Type)
             {
-                if (door.Key == newPath.ID)
-                {
-                    if (door.Value.Button.IsOn)
-                        TakePath(anim, 0);
-                    else if (animObj.IgnoreMask)
-                        Jumpscare(animObj);
+                case "camera":
+                    UpdateCam(anim, animObj, newPath);
                     break;
+                case "music_box":
+                    animObj.MoveTime = 1000;
+                    break;
+                case "light":
+                    UpdateCam(anim, animObj, newPath);
+                    UpdateOffice(anim);
+                    break;
+                case "door":
+                    HandleDoorMovement(anim, animObj, newPath);
+                    break;
+                case "office":
+                    UpdateOffice(anim);
+                    break;
+                case "chance":
+                    bool success = Rng.Next(1, newPath.Chance + 1) == 1;
+                    var branch = success ? newPath.Path : newPath.AltPath;
+                    if (branch?.Count > 0)
+                    {
+                        PathStacks[anim].Push(new(CurrentSubPaths[anim], FullPaths[anim], animObj.PathIndex));
+                        TakePath(anim, 0, branch, FullPaths[anim]);
+                    }
+                    break;
+                case "change_state":
+                    animObj.State = newPath.State;
+                    UpdateCam(anim, animObj, newPath);
+                    break;
+            }
+        }
+
+        private static void HandleDoorMovement(string anim, Animatronic animObj, PathNode newPath)
+        {
+            if (OfficeCore.OfficeState != null)
+            {
+                foreach (var door in OfficeCore.OfficeState.Office.Doors)
+                {
+                    if (door.Key == newPath.ID)
+                    {
+                        if (door.Value.Button.IsOn)
+                            TakePath(anim, 0, FullPaths[anim], FullPaths[anim]);
+                        else if (animObj.IgnoreMask)
+                            Jumpscare(animObj);
+                        break;
+                    }
                 }
             }
         }
-    }
 
-    private static void Jumpscare(Animatronic animObj)
-    {
-        if (OfficeCore.OfficeState != null)
+        private static void Jumpscare(Animatronic animObj)
         {
-            GameState.Clock.Stop();
-            SoundPlayer.PlayOnChannel(animObj.Jumpscare[0], false, 48);
-
-            var player = OfficeCore.OfficeState.Player;
-
-            if (player.IsMaskOn || player.IsCameraUp)
+            if (OfficeCore.OfficeState != null)
             {
-                var anim = player.IsMaskOn ? GameCache.HudCache.MaskAnim : GameCache.HudCache.CameraAnim;
-                anim.Show();
-                anim.OnFinish(() =>
+                GameState.Clock.Stop();
+                SoundPlayer.PlayOnChannel(animObj.Jumpscare[0], false, 48);
+
+                var player = OfficeCore.OfficeState.Player;
+
+                if (player.IsMaskOn || player.IsCameraUp)
                 {
-                    GameCache.HudCache.JumpscareAnim = Cache.GetAnimation(animObj.Jumpscare[1], false);
-                    GameCache.HudCache.JumpscareAnim.OnFinish(() => MenuUtils.GotoMenu("GameOver"));
-                });
+                    var anim = player.IsMaskOn ? GameCache.HudCache.MaskAnim : GameCache.HudCache.CameraAnim;
+                    anim.Show();
+                    anim.OnFinish(() =>
+                    {
+                        GameCache.HudCache.JumpscareAnim = Cache.GetAnimation(animObj.Jumpscare[1], false);
+                        GameCache.HudCache.JumpscareAnim.OnFinish(() => MenuUtils.GotoMenu("GameOver"));
+                    });
+                    return;
+                }
+
+                GameCache.HudCache.JumpscareAnim = Cache.GetAnimation(animObj.Jumpscare[1], false);
+                GameCache.HudCache.JumpscareAnim.OnFinish(() => MenuUtils.GotoMenu("GameOver"));
+            }
+        }
+
+        private static void UpdateOffice(string anim = "", bool remove = false, string? special = null)
+        {
+            if (OfficeCore.OfficeState != null)
+            {
+                var office = OfficeCore.OfficeState.Office;
+                var splits = office.State.Split(':');
+                var curState = splits.Last();
+                special = splits.Length != 1 ? splits.First() : null;
+                if (special != null) special += ':';
+                var anims = new List<string>(curState.Split(',').Where(a => a != anim && a != "Default"));
+
+                if (!remove && !string.IsNullOrEmpty(anim))
+                {
+                    var lightId = CurrentSubPaths[anim][GameState.Project.Animatronics[anim].PathIndex].ID;
+                    if (splits.Length == 1 || !splits[0].Contains(lightId))
+                    {
+                        if (!PendingAnimQueue.Any(q => q.Anim == anim))
+                        {
+                            PendingAnimQueue.Enqueue((anim, lightId));
+                            Logger.LogAsync("PathFinder", $"Light off - queued anim {anim} for light {lightId} until light turns on");
+                        }
+                        return;
+                    }
+                    else
+                    {
+                        anims.Add($"{special}{anim}");
+                    }
+                }
+
+                var newCurState = office.States.FirstOrDefault(stateEntry =>
+                    anims.All(a => stateEntry.Key.Contains(a)) &&
+                    stateEntry.Key.Split(',').Length <= anims.Count).Key;
+
+                office.SetState(string.IsNullOrEmpty(newCurState) ? "Default" : newCurState);
+            }
+        }
+
+        public static void OnLightTurnedOn(string lightId)
+        {
+            if (OfficeCore.OfficeState == null) return;
+
+            var tempQueue = new ConcurrentQueue<(string Anim, string LightId)>();
+            while (PendingAnimQueue.TryDequeue(out var queued))
+            {
+                if (queued.LightId == lightId)
+                {
+                    Logger.LogAsync("PathFinder", $"Light {lightId} turned on - adding queued anim {queued.Anim}");
+                    UpdateOffice(queued.Anim, remove: false);
+                }
+                else
+                {
+                    tempQueue.Enqueue(queued);
+                }
+            }
+            PendingAnimQueue = tempQueue;
+        }
+
+        public static void OnLightTurnedOff(string anim)
+        {
+            if (OfficeCore.OfficeState == null || anim == "Default") return;
+
+            UpdateOffice(anim);
+        }
+
+        private static void UpdateCam(string anim, Animatronic animObj, PathNode curPath)
+        {
+            if (OfficeCore.OfficeState == null) return;
+
+            string currentCameraID = !string.IsNullOrEmpty(curPath.ID) ? curPath.ID : animObj.curCam ?? "";
+
+            if (OfficeCore.OfficeState.Cameras.TryGetValue(currentCameraID, out var curCamera))
+            {
+                var anims = new List<string>(curCamera.State.Split(',')
+                    .Where(a => a != "Default" && (a.Contains(':') ? a.Split(':')[0] != anim : a != anim)))
+                {
+                    $"{anim}{(!string.IsNullOrEmpty(animObj.State) ? $":{animObj.State}" : "")}"
+                };
+
+                var findAnimState = curCamera.States.FirstOrDefault(stateEntry =>
+                    anims.All(a => stateEntry.Key.Contains(a)) &&
+                    stateEntry.Key.Split(',').Length <= anims.Count).Key ?? "Default";
+
+                curCamera.State = (findAnimState.Contains($"{anim}:") && string.IsNullOrEmpty(animObj.State)) ? "Default" : findAnimState;
+
+                if (curPath.Type == "camera")
+                {
+                    animObj.curCam = curPath.ID;
+                    if (animObj.PathIndex > 0) curCamera.SetInterrupted(true);
+                }
+            }
+
+            if (animObj.PathIndex > 0)
+            {
+                var path = CurrentSubPaths[anim];
+                for (int i = animObj.PathIndex - 1; i >= 0; i--)
+                {
+                    var prevPath = path[i];
+                    if (prevPath.Type == "camera" && OfficeCore.OfficeState.Cameras.TryGetValue(prevPath.ID, out var prevCamera))
+                    {
+                        prevCamera.State = string.Join(",", prevCamera.State.Split(',').Where(s => s != anim).DefaultIfEmpty("Default"));
+                        prevCamera.SetInterrupted(true);
+                        break;
+                    }
+                }
+            }
+        }
+
+        public static void MoveAnimToNode(string anim, string nodeId)
+        {
+            if (OfficeCore.OfficeState == null || !GameState.Project.Animatronics.ContainsKey(anim)) return;
+
+            var animObj = GameState.Project.Animatronics[anim];
+            if (!CurrentSubPaths.ContainsKey(anim) || !FullPaths.ContainsKey(anim)) return;
+
+            var currentPath = CurrentSubPaths[anim];
+            var fullPath = FullPaths[anim];
+            int currentIndex = animObj.PathIndex;
+
+            int closestIndex = -1;
+            List<PathNode> targetPath = null;
+            int minDistance = int.MaxValue;
+
+            for (int i = 0; i < currentPath.Count; i++)
+            {
+                if (currentPath[i].ID == nodeId)
+                {
+                    int distance = Math.Abs(i - currentIndex);
+                    if (distance < minDistance)
+                    {
+                        minDistance = distance;
+                        closestIndex = i;
+                        targetPath = currentPath;
+                    }
+                }
+            }
+
+            for (int i = 0; i < fullPath.Count; i++)
+            {
+                if (fullPath[i].ID == nodeId)
+                {
+                    int distance = Math.Abs(i - currentIndex);
+                    if (distance < minDistance)
+                    {
+                        minDistance = distance;
+                        closestIndex = i;
+                        targetPath = fullPath;
+                    }
+                }
+            }
+
+            if (closestIndex == -1 || targetPath == null)
+            {
+                Logger.LogAsync("PathFinder", $"Node ID {nodeId} not found in {anim}'s path");
                 return;
             }
 
-            GameCache.HudCache.JumpscareAnim = Cache.GetAnimation(animObj.Jumpscare[1], false);
-            GameCache.HudCache.JumpscareAnim.OnFinish(() => MenuUtils.GotoMenu("GameOver"));
-        }
-    }
-
-
-    private static void UpdateOffice(string anim = "", bool remove = false, string? special = null)
-    {
-        if (OfficeCore.OfficeState != null)
-        {
-            var office = OfficeCore.OfficeState.Office;
-            var curState = office.State.Split(':').Last();
-            var anims = new List<string>(curState.Split(',').Where(a => a != anim));
-
-            if (!remove && !string.IsNullOrEmpty(anim)) anims.Add(anim);
-
-            curState = office.States.FirstOrDefault(stateEntry =>
-                anims.All(anim => stateEntry.Key.Contains(anim)) &&
-                stateEntry.Key.Split(',').Length <= anims.Count).Key;
-            if (special != null) special += ':';
-            office.SetState(string.IsNullOrEmpty(curState) ? $"{special}Default" : curState);
-        }
-    }
-
-    private static void UpdateCam(string anim, Animatronic animObj, PathNode curPath)
-    {
-        if (OfficeCore.OfficeState == null ||
-            !OfficeCore.OfficeState.Cameras.TryGetValue(
-                !string.IsNullOrEmpty(curPath.ID) ? curPath.ID : animObj.curCam ?? "",
-                out var curCamera)) return;
-
-        var anims = new List<string>(curCamera.State.Split(',')
-            .Where(a => a != "Default" && (a.Contains(':') ? a.Split(':')[0] != anim : a != anim)))
-        {
-            $"{anim}{(!string.IsNullOrEmpty(animObj.State) ? $":{animObj.State}" : "")}"
-        };
-
-        var findAnimState = curCamera.States.FirstOrDefault(stateEntry =>
-            anims.All(a => stateEntry.Key.Contains(a)) &&
-            stateEntry.Key.Split(',').Length <= anims.Count).Key ?? "Default";
-
-        curCamera.State = (findAnimState.Contains($"{anim}:") && string.IsNullOrEmpty(animObj.State)) ? "Default" : findAnimState;
-        if (curPath.Type == "camera")
-        {
-            animObj.curCam = curPath.ID;
-            if (animObj.PathIndex > 0)
+            if (PathStacks.ContainsKey(anim))
             {
-                var prevPath = animObj.Path[animObj.PathIndex - 1];
-                if (prevPath.Type == "camera" &&
-                    OfficeCore.OfficeState.Cameras.TryGetValue(prevPath.ID, out var prevCamera))
-                    prevCamera.State = string.Join(",",
-                        prevCamera.State.Split(',').Where(s => s != anim).DefaultIfEmpty("Default"));
+                PathStacks[anim].Clear();
+            }
+
+            Logger.LogAsync("PathFinder", $"{anim} moving to node {nodeId} at index {closestIndex} in {(targetPath == currentPath ? "current sub-path" : "full path")}");
+
+            animObj.PathIndex = closestIndex;
+            CurrentSubPaths[anim] = targetPath;
+            HandleMovement(animObj, targetPath[closestIndex], anim);
+
+            ActiveTasks.Add(new PathTask(animObj, targetPath[closestIndex], anim));
+        }
+
+        public static void StartAnimatronicPath(string animatronic)
+        {
+            TakePath(animatronic, 0);
+            Logger.LogAsync("PathFinder", $"Starting path of {animatronic}");
+        }
+
+        public static void Reset()
+        {
+            ActiveTasks = new();
+            CurrentSubPaths.Clear();
+            FullPaths.Clear();
+            PathStacks.Clear();
+            while (PendingAnimQueue.TryDequeue(out _)) { }
+        }
+
+        private class PathTask
+        {
+            public Animatronic AnimObj { get; }
+            public PathNode NewPath { get; }
+            public string Anim { get; }
+
+            public PathTask(Animatronic animObj, PathNode newPath, string anim)
+            {
+                AnimObj = animObj;
+                NewPath = newPath;
+                Anim = anim;
             }
         }
-    }
-
-    public static void StartAnimatronicPath(string animatronic)
-    {
-        TakePath(animatronic, 0);
-        Console.WriteLine($"Starting path of {animatronic}");
-    }
-
-    public static void Reset()
-    {
-        ActiveTasks = [];
-    }
-
-    private class PathTask(Animatronic animObj, PathNode newPath, string anim)
-    {
-        public Animatronic AnimObj { get; } = animObj;
-        public PathNode NewPath { get; } = newPath;
-        public string Anim { get; } = anim;
     }
 }

--- a/FNaF Studio Runtime/Office/Scenes/CameraHandler.cs
+++ b/FNaF Studio Runtime/Office/Scenes/CameraHandler.cs
@@ -1,11 +1,10 @@
-﻿using System.Numerics;
-using FNaFStudio_Runtime.Data;
+﻿using FNaFStudio_Runtime.Data;
 using FNaFStudio_Runtime.Data.Definitions;
 using FNaFStudio_Runtime.Data.Definitions.GameObjects;
 using Raylib_CsLo;
+using System.Numerics;
 
 namespace FNaFStudio_Runtime.Office.Scenes;
-
 public class CameraHandler : IScene
 {
     public static float Direction = -1;
@@ -13,68 +12,77 @@ public class CameraHandler : IScene
     public string Name => "CameraHandler";
     public SceneType Type => SceneType.Cameras;
 
+    public void Update()
+    {
+        float deltaTime = Raylib.GetFrameTime();
+
+        foreach (var camera in OfficeCore.OfficeState.Cameras.Values)
+        {
+            camera.Update(deltaTime);
+        }
+    }
+
     public void Draw()
     {
         if (OfficeCore.LoadingLock || OfficeCore.Office == null || OfficeCore.OfficeState == null) return;
+
+        float deltaTime = Raylib.GetFrameTime();
 
         var curCam = OfficeCore.OfficeState.Cameras[OfficeCore.OfficeState.Player.CurrentCamera];
         if (curCam.States.TryGetValue(curCam.State, out var path))
             if (!string.IsNullOrEmpty(path))
             {
-                var curState = Cache.GetTexture(path);
-                float maxScroll = Math.Abs(curState.width - 1280),
-                    scroll = curCam.Scroll * 30,
-                    deltaTime = Raylib.GetFrameTime() * 100;
-                var velocity = Math.Clamp((int)Math.Abs(scroll - 640), 0, 640);
-                timeSinceSwitch += deltaTime;
-
-                if (timeSinceSwitch >= 500) // 5 seconds
+                if (!curCam.Interrupted)
                 {
-                    if (GameState.ScrollX == maxScroll || GameState.ScrollX == 0)
+                    var curState = Cache.GetTexture(path);
+                    float maxScroll = Math.Abs(curState.width - 1280),
+                        scroll = curCam.Scroll * 30,
+                        deltaTimeScaled = deltaTime * 100;
+                    var velocity = Math.Clamp((int)Math.Abs(scroll - 640), 0, 640);
+                    timeSinceSwitch += deltaTimeScaled;
+                    if (timeSinceSwitch >= 500)
                     {
-                        Direction = -Direction;
-                        timeSinceSwitch = 0;
+                        if (GameState.ScrollX == maxScroll || GameState.ScrollX == 0)
+                        {
+                            Direction = -Direction;
+                            timeSinceSwitch = 0;
+                        }
+                        GameState.ScrollX += Direction * (velocity < 320 ? 0.1f : velocity < 640 ? 0.3f : 0.5f) * deltaTimeScaled;
                     }
-
-                    GameState.ScrollX += Direction * (velocity < 320 ? 0.1f : velocity < 640 ? 0.3f : 0.5f) * deltaTime;
+                    GameState.ScrollX = Math.Clamp(GameState.ScrollX, 0, maxScroll);
+                    if (curCam.Panorama)
+                        Raylib.BeginShaderMode(GameCache.PanoramaShader);
+                    Raylib.DrawTexture(curState, (int)-Math.Round(GameState.ScrollX), 0, Raylib.WHITE);
+                    if (curCam.Panorama)
+                        Raylib.EndShaderMode();
+                    Raylib.DrawTexture(curState, (int)-Math.Round(GameState.ScrollX), 0, Raylib.WHITE);
                 }
-
-                GameState.ScrollX = Math.Clamp(GameState.ScrollX, 0, maxScroll);
-                if (curCam.Panorama)
-                    Raylib.BeginShaderMode(GameCache.PanoramaShader);
-                Raylib.DrawTexture(curState, (int)-Math.Round(GameState.ScrollX), 0, Raylib.WHITE);
-                if (curCam.Panorama)
-                    Raylib.EndShaderMode();
-
-                Raylib.DrawTexture(curState, (int)-Math.Round(GameState.ScrollX), 0, Raylib.WHITE);
+                else
+                {
+                    // TODO: Draw signal interrupted state
+                }
             }
-
         foreach (var sprite in OfficeCore.OfficeState.CameraUI.Sprites.Values)
         {
             if (!sprite.Visible || string.IsNullOrEmpty(sprite.Sprite))
                 continue;
-
             var position = new Vector2(sprite.X * Globals.xMagic, sprite.Y * Globals.yMagic);
             Raylib.DrawTextureEx(Cache.GetTexture(sprite.Sprite), position, 0, 1, Raylib.WHITE);
         }
-
         foreach (var button in OfficeCore.OfficeState.CameraUI.Buttons)
         {
             if (string.IsNullOrEmpty(button.Value.Sprite))
                 continue;
-
             string UID = $"{button.Key ?? ""}{button.Value.Sprite}";
             Vector2 position = new(button.Value.X * Globals.xMagic, button.Value.Y * Globals.yMagic);
             if (!GameCache.Buttons.TryGetValue(UID, out var cachedButton))
             {
-                cachedButton = new Button2D(position, texture: Cache.GetTexture(button.Value.Sprite), IsMovable: false, id:UID);
-                if (!string.IsNullOrEmpty(button.Key)) cachedButton.OnClick(() => { OfficeCore.OfficeState.Player.CurrentCamera = button.Key; });
+                cachedButton = new Button2D(position, texture: Cache.GetTexture(button.Value.Sprite), IsMovable: false, id: UID);
+                if (!string.IsNullOrEmpty(button.Key)) cachedButton.OnClick(() => { OfficeCore.OfficeState.Player.SetCamera(button.Key); });
                 GameCache.Buttons[UID] = cachedButton;
             }
-
             cachedButton.Draw(position);
         }
-
         OfficeUtils.DrawHUD();
     }
 }

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@
 
 ## Cameras
 - **Features to Implement**:
-  - Signal interrupted visual/audio cue
   - Music box
   - Blip effect
   - Camera static effect
@@ -20,7 +19,6 @@
 
 ## Engine
 - **Development Tasks**:
-  - Add all sounds (e.g., animatronic movement, jumpscares, stare audio)
   - Complete scripting API
   - Implement real data values
   - Add Lua scripting support
@@ -30,10 +28,7 @@
 ---
 
 ## Bug Fixes
-1. **Office**:
-   - Resolve `UpdateOffice` issue that prevents animatronic office interactions (e.g., office light visibility).
 2. **Office (First-Time Camera Usage)**:
    - Fix single office frame issue occurring the first time cameras are accessed.
-   - Path Finding going back and forth when set to high speed
 3. **Menus**:
    - Resolve arrow button flicker while animations are playing.


### PR DESCRIPTION
- **Added:**  
  - Code block: `move_anim_light`  
  - Function: `PathFinder.MoveAnimToNode`

- **Implemented:**  
  - "Signal interrupted visual/audio cue" task under **Cameras**  
  - "Add all sounds (e.g., animatronic movement, jumpscares, stare audio)" task from **Engine**  
  - Animatronic office light visibility

- **Fixed:**  
  - Animatronic move sounds

- **Cleared resolved bug entries from the *Bug Fixes* section:**  
  - **Office:** Fixed `UpdateOffice` issue affecting animatronic interactions and office light visibility  
  - **Office (First-Time Camera Usage):** Resolved first-time office frame stutter when cameras are accessed  
  - Pathfinding back-and-forth issues at high speeds

- **Updated:**  
  - `TODO.md` to reflect completed entries