### PR TITLE
 Refactor Runtime: SignalInterrupted Texture, Address Mass Allocs, Merge Upstream

### DIFF
--- a/FNaF Studio Editor/Controls/SideBar.cs
+++ b/FNaF Studio Editor/Controls/SideBar.cs
@@ -36,7 +36,7 @@ public class SideBar
     private void LoadTexture2Ds()
     {
         byte[][] textureResources =
-        {
+        [
             Assets.Assets.createproject,
             Assets.Assets.openproject,
             Assets.Assets.templates,
@@ -49,7 +49,7 @@ public class SideBar
             Assets.Assets.animations,
             Assets.Assets.sounds,
             Assets.Assets.scripteditor
-        };
+        ];
 
         foreach (var textureData in textureResources)
             unsafe

--- a/FNaF Studio Runtime/Data/CRScript/MathEvaluator.cs
+++ b/FNaF Studio Runtime/Data/CRScript/MathEvaluator.cs
@@ -46,14 +46,14 @@ public class Token
     public static Token ParenRight => new(TokenType.ParenR);
 }
 
-public class MathEvaluator
+public abstract class MathEvaluator
 {
     public static double Evaluate(string expression)
     {
         try
         {
             var tokens = Tokenize(expression);
-            var (ast, _) = Parse(tokens);
+            var ast = Parse(tokens);
             return EvaluateAst(ast);
         }
         catch
@@ -66,6 +66,7 @@ public class MathEvaluator
     {
         var tokens = new List<Token>();
         var chars = expression.GetEnumerator();
+        using var chars1 = chars as IDisposable;
         while (chars.MoveNext())
         {
             var c = chars.Current;
@@ -128,7 +129,7 @@ public class MathEvaluator
         return tokens;
     }
 
-    private static (List<Token>, int) Parse(List<Token> tokens)
+    private static List<Token> Parse(List<Token> tokens)
     {
         var output = new List<Token>();
         var operators = new Stack<Token>();
@@ -164,7 +165,7 @@ public class MathEvaluator
 
         while (operators.Count > 0) output.Add(operators.Pop());
 
-        return (output, i);
+        return output;
     }
 
     private static int Precedence(Token token)

--- a/FNaF Studio Runtime/Data/Core.cs
+++ b/FNaF Studio Runtime/Data/Core.cs
@@ -9,47 +9,46 @@ namespace FNaFStudio_Runtime.Data;
 
 public static class Globals
 {
-    public const float xMagic = 2.13333333f;
-    public const float yMagic = 2.13649852f;
+    public const float XMagic = 2.13333333f;
+    public const float YMagic = 2.13649852f;
 
     public static string GetStaticImage(byte value)
     {
-        if (value < 1) throw new ArgumentException("Static Image value is below 1.");
-        if (value > 8) throw new ArgumentException("Static Image value is above 8.");
-
-        return $"e.static{value}.png";
+        return value switch
+        {
+            < 1 => throw new ArgumentException("Static Image value is below 1."),
+            > 8 => throw new ArgumentException("Static Image value is above 8."),
+            _ => $"e.static{value}.png"
+        };
     }
 }
 
 public static class MenusCore
 {
-    public static string Menu { get; set; } = string.Empty;
     public static int CurrentStaticImageIndex { get; set; }
     public static Dictionary<string, Menu> Menus { get; } = [];
     public static bool ArrowIn { get; internal set; }
 
-    public static Menu? ConvertMenuToAPI(GameJson.Menu menu)
+    public static Menu ConvertMenuToApi(GameJson.Menu menu)
     {
         var cacheMenu = new Menu();
 
-        foreach (var el in menu.Elements)
+        foreach (var newElement in menu.Elements.Select(el => new MenuElement
+                 {
+                     Color = RuntimeUtils.ParseIntToColor(el.Red, el.Green, el.Blue),
+                     Animation = el.Animation,
+                     Animatronic = el.Animatronic,
+                     FontName = el.Fontname,
+                     FontSize = el.Fontsize,
+                     Hidden = el.Hidden,
+                     Text = el.Text,
+                     Id = el.ID,
+                     Sprite = el.Sprite,
+                     X = (int)(el.X * Globals.XMagic),
+                     Y = (int)(el.Y * Globals.XMagic),
+                     Type = el.Type
+                 }))
         {
-            var newElement = new MenuElement
-            {
-                Color = RuntimeUtils.ParseIntToColor(el.Red, el.Green, el.Blue),
-                Animation = el.Animation,
-                Animatronic = el.Animatronic,
-                FontName = el.Fontname,
-                FontSize = el.Fontsize,
-                Hidden = el.Hidden,
-                Text = el.Text,
-                ID = el.ID,
-                Sprite = el.Sprite,
-                X = (int)(el.X * Globals.xMagic),
-                Y = (int)(el.Y * Globals.xMagic),
-                Type = el.Type
-            };
-
             cacheMenu.Elements.Add(newElement);
         }
 
@@ -59,7 +58,7 @@ public static class MenusCore
         return cacheMenu;
     }
 
-    public static GameJson.Properties DeepCopyProperties(GameJson.Properties props)
+    private static GameJson.Properties DeepCopyProperties(GameJson.Properties props)
     {
         return new GameJson.Properties
         {
@@ -91,17 +90,17 @@ public static class OfficeCore
 
 public static class GameState
 {
-    public static string SelectedButtonID = string.Empty;
+    public static string SelectedButtonId = string.Empty;
 
-    public static TickManager Clock = new();
+    public static readonly TickManager Clock = new();
 
     public static bool DebugMode = false;
 
-    public static List<IScene> Scenes = [];
+    public static readonly List<IScene> Scenes = [];
     public static IScene CurrentScene = new MenuHandler();
 
     public static GameJson.Game Project = new();
-    public static readonly object buttonsLock = new();
+    public static readonly object ButtonsLock = new();
 
     public static string ProjectPath { get; set; } = "assets";
     public static float ScrollX { get; set; }

--- a/FNaF Studio Runtime/Data/Definitions/GameObjects/Animation.cs
+++ b/FNaF Studio Runtime/Data/Definitions/GameObjects/Animation.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Numerics;
+﻿using System.Numerics;
 using FNaFStudio_Runtime.Util;
 using Newtonsoft.Json;
 using Raylib_CsLo;
@@ -14,7 +11,7 @@ namespace FNaFStudio_Runtime.Data.Definitions.GameObjects
         private readonly List<int> frameSpeeds;
         private int currentFrame;
         private int frameCount;
-        public bool looping = true;
+        private readonly bool looping;
         private float timer;
         private bool isPaused;
         private bool isHidden;
@@ -42,14 +39,14 @@ namespace FNaFStudio_Runtime.Data.Definitions.GameObjects
         private void LoadFrames(string file)
         {
             if (!File.Exists(file)) throw new FileNotFoundException("The specified JSON file was not found.", file);
-            var JsonFrames = JsonConvert.DeserializeObject<AJson.Frame[]>(File.ReadAllText(file));
-            if (JsonFrames == null)
+            var jsonFrames = JsonConvert.DeserializeObject<AJson.Frame[]>(File.ReadAllText(file));
+            if (jsonFrames == null)
             {
                 Logger.LogFatalAsync("BaseAnimation", "JsonFrames is null.");
                 return;
             }
 
-            foreach (var frame in JsonFrames)
+            foreach (var frame in jsonFrames)
             {
                 frames.Add(frame.Sprite);
                 frameSpeeds.Add(frame.Duration);
@@ -71,7 +68,7 @@ namespace FNaFStudio_Runtime.Data.Definitions.GameObjects
 
             if (!playTriggered && onPlayActions?.Count > 0)
             {
-                onPlayActions.ForEach(action => action?.Invoke());
+                onPlayActions.ForEach(action => action());
                 playTriggered = true;
             }
 
@@ -93,7 +90,7 @@ namespace FNaFStudio_Runtime.Data.Definitions.GameObjects
 
                 if (!looping && !HasFramesLeft() && onFinishActions?.Count > 0)
                 {
-                    onFinishActions.ForEach(action => action?.Invoke());
+                    onFinishActions.ForEach(action => action());
                 }
             }
         }

--- a/FNaF Studio Runtime/Data/Definitions/GameObjects/Button.cs
+++ b/FNaF Studio Runtime/Data/Definitions/GameObjects/Button.cs
@@ -14,39 +14,39 @@ public class Button2D
     private Action? onClick;
     private Action? onRelease;
 
-    private Text? Text;
-    private Texture? Texture;
+    private Text? text;
+    private Texture? texture;
 
-    public Button2D(Vector2 position, GameJson.OfficeObject? obj = null, MenuElement? element = null, string? id = "", bool IsMovable = true,
-        bool IsVisible = true, Texture? texture = null, Text? text = null, Action? onHover = null, Action? onClick = null,
+    public Button2D(Vector2 position, GameJson.OfficeObject? obj = null, MenuElement? element = null, string? id = "", bool isMovable = true,
+        bool isVisible = true, Texture? texture = null, Text? text = null, Action? onHover = null, Action? onClick = null,
         Action? onRelease = null)
     {
         var tex = texture ?? GetTextureSafe(element?.Sprite ?? obj?.Sprite);
-        ID = id ?? Element?.ID ?? Object?.ID ?? "";
+        Id = id ?? Element?.Id ?? Object?.ID ?? "";
         Bounds = CreateBounds(position, tex, text);
-        Text = text;
+        this.text = text;
         Element = element;
         Object = obj;
         IsImage = texture.HasValue;
-        Texture = texture;
+        this.texture = texture;
         this.onHover = onHover;
         this.onClick = onClick;
         this.onRelease = onRelease;
-        this.IsMovable = IsMovable;
-        this.IsVisible = IsVisible;
+        this.IsMovable = isMovable;
+        this.IsVisible = isVisible;
     }
 
-    public string ID { get; private set; } = string.Empty;
-    public bool IsMovable { get; set; }
+    public string Id { get; private set; }
+    private bool IsMovable { get; set; }
     public bool IsVisible { get; set; }
-    public Rectangle Bounds { get; }
+    private Rectangle Bounds { get; }
     public bool IsHoverable { get; private set; } = true;
     public bool IsHovered { get; private set; }
-    public bool IsClicked { get; private set; }
+    private bool IsClicked { get; set; }
     public bool IsClickable { get; private set; } = true;
-    public bool IsImage { get; }
-    public MenuElement? Element { get; }
-    public GameJson.OfficeObject? Object { get; }
+    private bool IsImage { get; }
+    private MenuElement? Element { get; }
+    private GameJson.OfficeObject? Object { get; }
 
     private static Rectangle CreateBounds(Vector2 position, Texture? texture, Text? text)
     {
@@ -101,10 +101,10 @@ public class Button2D
     {
         if (!IsVisible) return;
 
-        var Temp = Bounds;
-        if (IsMovable) Temp.X -= xOffset;
+        var temp = Bounds;
+        if (IsMovable) temp.X -= xOffset;
         var mousePosition = Raylib.GetMousePosition();
-        IsHovered = Raylib.CheckCollisionPointRec(mousePosition, Temp);
+        IsHovered = Raylib.CheckCollisionPointRec(mousePosition, temp);
         IsClicked = IsHovered && Raylib.IsMouseButtonPressed(MouseButton.MOUSE_BUTTON_LEFT);
 
         if (IsHovered) HandleHover();
@@ -117,25 +117,25 @@ public class Button2D
 
     private void HandleHover()
     {
-        if (ID != null && GameState.SelectedButtonID != ID)
+        if (GameState.SelectedButtonId != Id)
         {
-            GameState.SelectedButtonID = ID;
+            GameState.SelectedButtonId = Id;
             onHover?.Invoke();
 
             // This already handles menu-specific logic
             if (Element != null)
             {
                 EventManager.TriggerEvent("any_button_selected", []);
-                EventManager.TriggerEvent("button_selected", [Element.ID]);
+                EventManager.TriggerEvent("button_selected", [Element.Id]);
             }
         }
     }
 
     private void HandleUnHover()
     {
-        if (ID != null && GameState.SelectedButtonID == ID)
+        if (GameState.SelectedButtonId == Id)
         {
-            GameState.SelectedButtonID = string.Empty;
+            GameState.SelectedButtonId = string.Empty;
 
             onUnHover?.Invoke();
 
@@ -143,7 +143,7 @@ public class Button2D
             if (Element != null)
             {
                 EventManager.TriggerEvent("any_button_deselected", []);
-                EventManager.TriggerEvent("button_deselected", [Element.ID]);
+                EventManager.TriggerEvent("button_deselected", [Element.Id]);
             }
         }
     }
@@ -168,7 +168,7 @@ public class Button2D
         {
             DrawImage(position, on);
         }
-        else if (Text != null)
+        else if (text != null)
         {
             if (Element != null)
                 DrawTextElement(position);
@@ -185,31 +185,31 @@ public class Button2D
         sprite ??= Element?.Sprite;
 
         if (sprite != null)
-            Texture = Cache.GetTexture(sprite);
+            texture = Cache.GetTexture(sprite);
 
-        if (Texture.HasValue)
-            Raylib.DrawTextureEx((Texture)Texture, position, 0, 1, Raylib.WHITE);
+        if (texture.HasValue)
+            Raylib.DrawTextureEx((Texture)texture, position, 0, 1, Raylib.WHITE);
     }
 
     private void DrawTextObject(Vector2 position)
     {
-        if (Object != null && Object.Text != null && Text != null && Object.Text != Text.Content)
+        if (Object != null && text != null && Object.Text != text.Content)
         {
-            var uid = Object.Text ?? "";
-            Text = new Text(Object.Text ?? "", 36, "Arial", Raylib.WHITE);
-            GameCache.Texts[uid] = Text;
+            var uid = Object.Text;
+            text = new Text(Object.Text, 36, "Arial", Raylib.WHITE);
+            GameCache.Texts[uid] = text;
         }
 
-        Text?.Draw(position);
+        text?.Draw(position);
     }
 
     private void DrawTextElement(Vector2 position)
     {
-        if (IsHovered && MenuHandler.menuReference.Properties.ButtonArrows && !MenusCore.ArrowIn)
+        if (IsHovered && MenuHandler.MenuReference.Properties.ButtonArrows && !MenusCore.ArrowIn)
         {
             if (Element != null)
-                Raylib.DrawTextEx(Text!.Font, ">> ", new Vector2(position.X - Element.FontSize * 1.5f, position.Y),
-                    Text.FontSize, 1, Raylib.WHITE);
+                Raylib.DrawTextEx(text!.Font, ">> ", new Vector2(position.X - Element.FontSize * 1.5f, position.Y),
+                    text.FontSize, 1, Raylib.WHITE);
             MenusCore.ArrowIn = true;
         }
         else
@@ -217,13 +217,13 @@ public class Button2D
             MenusCore.ArrowIn = false;
         }
 
-        if (Element != null && Text != null && Element.Text != Text.Content)
+        if (Element != null && text != null && Element.Text != text.Content)
         {
             var uid = $"{Element.Text}-{Element.FontSize}";
-            Text = new Text(Element.Text, Element.FontSize, Element.FontName, Raylib.WHITE);
-            GameCache.Texts[uid] = Text;
+            text = new Text(Element.Text, Element.FontSize, Element.FontName, Raylib.WHITE);
+            GameCache.Texts[uid] = text;
         }
 
-        Text?.Draw(position);
+        text?.Draw(position);
     }
 }

--- a/FNaF Studio Runtime/Main.cs
+++ b/FNaF Studio Runtime/Main.cs
@@ -9,7 +9,7 @@ namespace FNaFStudio_Runtime;
 
 public class Runtime
 {
-    public Color FPSTextColor;
+    private Color fpsTextColor;
     private readonly ManualResetEvent updateSignal = new(false);
     private readonly ManualResetEvent mainSignal = new(false);
     private bool isRunning = true;
@@ -39,7 +39,7 @@ public class Runtime
         runtime.Run().HandleExceptions();
     }
 
-    public async Task Run()
+    private async Task Run()
     {
         RuntimeUtils.Scene.LoadScenes();
         Logger.Initialize();
@@ -52,18 +52,15 @@ public class Runtime
         Raylib.InitAudioDevice();
         RuntimeUtils.SetGameIcon(GameState.Project.GameInfo.Icon);
 
-        unsafe
-        {
-            Shader shader = Raylib.LoadShader(null, "RPanorama.glsl");
-            Raylib.SetShaderValue(shader, Raylib.GetShaderLocation(shader, "fPixelHeight"), 0.065f, ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
-            Raylib.SetShaderValue(shader, Raylib.GetShaderLocation(shader, "zoom"), 4, ShaderUniformDataType.SHADER_UNIFORM_INT);
-            Raylib.SetShaderValue(shader, Raylib.GetShaderLocation(shader, "noWrap"), 0, ShaderUniformDataType.SHADER_UNIFORM_INT);
-            GameCache.PanoramaShader = shader;
-        }
+        Shader shader = Raylib.LoadShader(null, "RPanorama.glsl");
+        Raylib.SetShaderValue(shader, Raylib.GetShaderLocation(shader, "fPixelHeight"), 0.065f, ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+        Raylib.SetShaderValue(shader, Raylib.GetShaderLocation(shader, "zoom"), 4, ShaderUniformDataType.SHADER_UNIFORM_INT);
+        Raylib.SetShaderValue(shader, Raylib.GetShaderLocation(shader, "noWrap"), 0, ShaderUniformDataType.SHADER_UNIFORM_INT);
+        GameCache.PanoramaShader = shader;
 
         RuntimeUtils.Scene.SetScene(SceneType.Menu);
         foreach (var menu in GameState.Project.Menus)
-            if (MenusCore.ConvertMenuToAPI(menu.Value) is { } newMenu)
+            if (MenusCore.ConvertMenuToApi(menu.Value) is { } newMenu)
                 MenusCore.Menus.Add(menu.Key, newMenu);
         MenuUtils.GotoMenu(GameState.Project.Menus.ContainsKey("Warning") ? "Warning" : "Main");
         GameState.Clock.Start();
@@ -77,7 +74,7 @@ public class Runtime
             {
                 updateSignal.Set();
                 foreach (var button in GameCache.Buttons.Values)
-                    button?.Update(GameState.ScrollX);
+                    button.Update(GameState.ScrollX);
             }
 
             mainSignal.WaitOne();
@@ -99,11 +96,11 @@ public class Runtime
             updateSignal.Reset();
 
             GameState.Clock.Update();
-            ScriptingAPI.TickEvents();
+            ScriptingApi.TickEvents();
             GameState.CurrentScene.Update();
             SoundPlayer.Update();
 
-            FPSTextColor = Raylib.GetFPS() switch
+            fpsTextColor = Raylib.GetFPS() switch
             {
                 >= 100 => Raylib.GREEN,
                 >= 60 => Raylib.WHITE,
@@ -114,7 +111,7 @@ public class Runtime
         }
     }
 
-    public void Draw()
+    private void Draw()
     {
         Raylib.BeginDrawing();
         Raylib.ClearBackground(Raylib.BLACK);
@@ -127,7 +124,7 @@ public class Runtime
             return;
         }
 
-        Raylib.DrawText($"{Raylib.GetFPS()} FPS", 0, 0, 22, FPSTextColor);
+        Raylib.DrawText($"{Raylib.GetFPS()} FPS", 0, 0, 22, fpsTextColor);
         Raylib.DrawText($"Current Scene: {GameState.CurrentScene.Name}", 0, 22, 22, Raylib.WHITE);
         Raylib.DrawText("Debug Mode", 0, 44, 22, Raylib.WHITE);
         Raylib.EndDrawing();

--- a/FNaF Studio Runtime/Menus/Definitions/MenuElement.cs
+++ b/FNaF Studio Runtime/Menus/Definitions/MenuElement.cs
@@ -8,7 +8,7 @@ public class MenuElement
     public string FontName { get; set; } = string.Empty;
     public int FontSize { get; set; }
     public bool Hidden { get; set; }
-    public string ID { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
     public string Text { get; set; } = string.Empty;
     public string Type { get; set; } = string.Empty;
     public string Sprite { get; set; } = string.Empty;

--- a/FNaF Studio Runtime/Menus/MenuHandler.cs
+++ b/FNaF Studio Runtime/Menus/MenuHandler.cs
@@ -1,14 +1,11 @@
-﻿using FNaFStudio_Runtime.Data;
-using FNaFStudio_Runtime.Data.CRScript;
-using FNaFStudio_Runtime.Data.Definitions;
+﻿using FNaFStudio_Runtime.Data.Definitions;
 using FNaFStudio_Runtime.Menus.Definitions;
-using FNaFStudio_Runtime.Util;
 
 namespace FNaFStudio_Runtime.Menus;
 
 public class MenuHandler : IScene
 {
-    public static Menu menuReference = new();
+    public static Menu MenuReference = new();
     public string Name => "Menus";
     public SceneType Type => SceneType.Menu;
 
@@ -20,7 +17,6 @@ public class MenuHandler : IScene
 
     public void Exit()
     {
-        menuReference = new Menu();
-        MenusCore.Menu = string.Empty;
+        MenuReference = new Menu();
     }
 }

--- a/FNaF Studio Runtime/Office/Definitions/OfficeAnimatronic.cs
+++ b/FNaF Studio Runtime/Office/Definitions/OfficeAnimatronic.cs
@@ -4,7 +4,7 @@ namespace FNaFStudio_Runtime.Office.Definitions;
 
 public class OfficeAnimatronic
 {
-    public List<int> AI = [];
+    public List<int> Ai = [];
 
     public bool IgnoresMask;
 

--- a/FNaF Studio Runtime/Office/Definitions/OfficeCamera.cs
+++ b/FNaF Studio Runtime/Office/Definitions/OfficeCamera.cs
@@ -8,8 +8,8 @@ public class OfficeCamera
     public string State = "Default";
     public Dictionary<string, string> States = [];
     public bool Static;
-    public bool Interrupted = false;
-    public float InterruptTimer = 0f;
+    public bool Interrupted;
+    public float InterruptTimer;
 
     public void SetState(string state)
     {

--- a/FNaF Studio Runtime/Office/Definitions/OfficePower.cs
+++ b/FNaF Studio Runtime/Office/Definitions/OfficePower.cs
@@ -10,7 +10,7 @@ public class OfficePower
     public int Level = 1;
     public float Accumulator = 0;
     public int Ticks = 9600;
-    public bool UCN;
+    public bool Ucn;
     public int Usage = 0;
 
     public class PowerOutAnim

--- a/FNaF Studio Runtime/Office/Definitions/Player.cs
+++ b/FNaF Studio Runtime/Office/Definitions/Player.cs
@@ -20,7 +20,7 @@ public class Player
     public void SetCamera(string cam)
     {
         CurrentCamera = cam;
-        SoundPlayer.SetChannelVolume(10, (OfficeCore.OfficeState.Cameras[cam].Interrupted && IsCameraUp) ? 100 : 0);
+        SoundPlayer.SetChannelVolume(10, OfficeCore.OfficeState != null && (OfficeCore.OfficeState.Cameras[cam].Interrupted && IsCameraUp) ? 100 : 0);
     }
 
     public void Putdown()

--- a/FNaF Studio Runtime/Office/OfficeUtils.cs
+++ b/FNaF Studio Runtime/Office/OfficeUtils.cs
@@ -7,123 +7,116 @@ using System.Numerics;
 
 namespace FNaFStudio_Runtime.Office;
 
-public class OfficeUtils
+public abstract class OfficeUtils
 {
     private static void Toggle(ref bool state)
     {
         state = !state;
     }
 
-    public static Button2D GetButtonWithCallback(string id, GameJson.OfficeObject obj, Action<Button2D>? setup = null)
+    private static Button2D GetButtonWithCallback(string id, GameJson.OfficeObject obj, Action<Button2D>? setup = null)
     {
-        if (!GameCache.Buttons.TryGetValue(id, out var button) && obj.Position != null &&
-            !string.IsNullOrEmpty(obj.Sprite))
-        {
-            var tex = Cache.GetTexture(obj.Sprite);
-            button = new Button2D(new Vector2(obj.Position[0] * Globals.xMagic, obj.Position[1] * Globals.yMagic), obj,
-                texture: tex);
-            setup?.Invoke(button);
-            GameCache.Buttons[id] = button;
-        }
+        if (GameCache.Buttons.TryGetValue(id, out var button) ||
+            string.IsNullOrEmpty(obj.Sprite)) return button!;
+        var tex = Cache.GetTexture(obj.Sprite);
+        button = new Button2D(new Vector2(obj.Position[0] * Globals.XMagic, obj.Position[1] * Globals.YMagic), obj,
+            texture: tex);
+        setup?.Invoke(button);
+        GameCache.Buttons[id] = button;
 
-        return button!;
+        return button;
     }
 
     public static Button2D GetDoorButton(string id, GameJson.OfficeObject obj)
     {
         return GetButtonWithCallback(id, obj, button =>
         {
-            if (OfficeCore.OfficeState != null && obj.ID != null)
+            if (OfficeCore.OfficeState == null) return;
+            var doorVars = OfficeCore.OfficeState.Office.Doors[obj.ID];
+            button.OnClick(() =>
             {
-                var doorVars = OfficeCore.OfficeState.Office.Doors[obj.ID];
-                button.OnClick(() =>
-                {
-                    if (doorVars.Animation != null && !doorVars.Animation.Current().HasFramesLeft())
-                    {
-                        Toggle(ref doorVars.IsClosed);
-                        Toggle(ref doorVars.Button.IsOn);
+                if (doorVars.Animation == null || doorVars.Animation.Current().HasFramesLeft()) return;
+                Toggle(ref doorVars.IsClosed);
+                Toggle(ref doorVars.Button.IsOn);
 
-                        if (doorVars.IsClosed)
-                        {
-                            SoundPlayer.PlayOnChannel(doorVars.CloseSound, false, 13);
-                            OfficeCore.OfficeState.Power.Usage += 1;
-                        }
-                        else
-                        {
-                            SoundPlayer.PlayOnChannel(doorVars.OpenSound, false, 13);
-                            OfficeCore.OfficeState.Power.Usage -= 1;
-                        }
-                        doorVars.Animation.Reverse();
-                    }
-                });
-            }
+                if (doorVars.IsClosed)
+                {
+                    SoundPlayer.PlayOnChannel(doorVars.CloseSound, false, 13);
+                    OfficeCore.OfficeState.Power.Usage += 1;
+                }
+                else
+                {
+                    SoundPlayer.PlayOnChannel(doorVars.OpenSound, false, 13);
+                    OfficeCore.OfficeState.Power.Usage -= 1;
+                }
+                doorVars.Animation.Reverse();
+            });
         });
     }
 
     public static Button2D GetLightButton(string id, GameJson.OfficeObject obj)
     {
-        if (OfficeCore.OfficeState == null || obj.ID == null)
+        if (OfficeCore.OfficeState == null)
             return GetButtonWithCallback(id, obj, _ => { });
 
         return GetButtonWithCallback(id, obj, button =>
         {
-            void HandleToggle()
-            {
-                if (OfficeCore.OfficeState != null)
-                {
-                    var stateParts = OfficeCore.OfficeState.Office.State.Split(':');
-                    var isLightOn = OfficeCore.OfficeState.Office.Lights[obj.ID].IsOn;
-                    if (stateParts.Length == 2 && !isLightOn)
-                    {
-                        Toggle(ref OfficeCore.OfficeState.Office.Lights[stateParts[0]].IsOn);
-                        OfficeCore.OfficeState.Power.Usage -= 1;
-
-                        OfficeCore.OfficeState.Office.State = $"{obj.ID}:{(stateParts[1]
-                                .Split(',')
-                                .Skip(1)
-                                .DefaultIfEmpty("Default")
-                                .Aggregate((acc, next) => acc + "," + next)
-                            )}";
-
-                        PathFinder.OnLightTurnedOff(stateParts[1].Split(',').First());
-                    }
-                    else
-                    {
-                        OfficeCore.OfficeState.Office.State = stateParts.Length == 2
-                            ?
-                            (stateParts[1]
-                                .Split(',')
-                                .Skip(1)
-                                .DefaultIfEmpty("Default")
-                                .Aggregate((acc, next) => acc + "," + next)
-                            )
-                            : $"{obj.ID}:{OfficeCore.OfficeState.Office.State}";
-                    }
-
-                    if (!isLightOn)
-                    {
-                        SoundPlayer.PlayOnChannel(obj.Sound, true, 12);
-                        OfficeCore.OfficeState.Power.Usage += 1;
-
-                        PathFinder.OnLightTurnedOn(obj.ID);
-                    }
-                    else
-                    {
-                        SoundPlayer.StopChannel(12);
-                        OfficeCore.OfficeState.Power.Usage -= 1;
-
-                        PathFinder.OnLightTurnedOff(stateParts[1].Split(',').First());
-
-                    }
-
-                    Toggle(ref OfficeCore.OfficeState.Office.Lights[obj.ID].IsOn);
-                }
-            }
-
             button.OnClick(HandleToggle);
 
             if (obj.Clickstyle)
                 button.OnRelease(HandleToggle);
+            return;
+
+            void HandleToggle()
+            {
+                if (OfficeCore.OfficeState == null) return;
+                var stateParts = OfficeCore.OfficeState.Office.State.Split(':');
+                var isLightOn = OfficeCore.OfficeState.Office.Lights[obj.ID].IsOn;
+                if (stateParts.Length == 2 && !isLightOn)
+                {
+                    Toggle(ref OfficeCore.OfficeState.Office.Lights[stateParts[0]].IsOn);
+                    OfficeCore.OfficeState.Power.Usage -= 1;
+
+                    OfficeCore.OfficeState.Office.State = $"{obj.ID}:{(stateParts[1]
+                            .Split(',')
+                            .Skip(1)
+                            .DefaultIfEmpty("Default")
+                            .Aggregate((acc, next) => acc + "," + next)
+                        )}";
+
+                    PathFinder.OnLightTurnedOff(stateParts[1].Split(',').First());
+                }
+                else
+                {
+                    OfficeCore.OfficeState.Office.State = stateParts.Length == 2
+                        ?
+                        (stateParts[1]
+                            .Split(',')
+                            .Skip(1)
+                            .DefaultIfEmpty("Default")
+                            .Aggregate((acc, next) => acc + "," + next)
+                        )
+                        : $"{obj.ID}:{OfficeCore.OfficeState.Office.State}";
+                }
+
+                if (!isLightOn)
+                {
+                    SoundPlayer.PlayOnChannel(obj.Sound, true, 12);
+                    OfficeCore.OfficeState.Power.Usage += 1;
+
+                    PathFinder.OnLightTurnedOn(obj.ID);
+                }
+                else
+                {
+                    SoundPlayer.StopChannel(12);
+                    OfficeCore.OfficeState.Power.Usage -= 1;
+
+                    PathFinder.OnLightTurnedOff(stateParts[1].Split(',').First());
+
+                }
+
+                Toggle(ref OfficeCore.OfficeState.Office.Lights[obj.ID].IsOn);
+            }
         });
     }
 
@@ -132,7 +125,7 @@ public class OfficeUtils
         if (OfficeCore.OfficeState == null) return;
 
         SoundPlayer.SetChannelVolume(10, 0);
-        (string, SceneType, int) checks = GameState.CurrentScene.Name == "CameraHandler" ?
+        var checks = GameState.CurrentScene.Name == "CameraHandler" ?
         (GameState.Project.Sounds.Camdown, SceneType.Office, -1) : (GameState.Project.Sounds.Camup, SceneType.Cameras, 1);
         SoundPlayer.PlayOnChannel(checks.Item1, false, 2);
         RuntimeUtils.Scene.SetScenePreserve(checks.Item2);
@@ -144,19 +137,19 @@ public class OfficeUtils
         if (OfficeCore.OfficeState == null) return;
 
         OfficeCore.OfficeState.Player.IsMaskOn = GameCache.HudCache.MaskAnim.State == AnimationState.Normal;
-        string maskSound = OfficeCore.OfficeState.Player.IsMaskOn ?
+        var maskSound = OfficeCore.OfficeState.Player.IsMaskOn ?
             GameState.Project.Sounds.Maskoff : GameState.Project.Sounds.Maskon;
         SoundPlayer.PlayOnChannel(maskSound, false, 3);
         GameCache.HudCache.MaskAnim.Resume();
         GameCache.HudCache.MaskAnim.Show();
     }
 
-    public static void ResetHUD()
+    public static void ResetHud()
     {
-        GameCache.HudCache.Power = new("", 26, GameState.Project.Offices[OfficeCore.Office ?? "Office"].TextFont ?? "LCD Solid", Raylib.WHITE);
-        GameCache.HudCache.Usage = new("", 26, GameState.Project.Offices[OfficeCore.Office ?? "Office"].TextFont ?? "LCD Solid", Raylib.WHITE);
-        GameCache.HudCache.Time = new("", 26, GameState.Project.Offices[OfficeCore.Office ?? "Office"].TextFont ?? "LCD Solid", Raylib.WHITE);
-        GameCache.HudCache.Night = new("", 22, GameState.Project.Offices[OfficeCore.Office ?? "Office"].TextFont ?? "LCD Solid", Raylib.WHITE);
+        GameCache.HudCache.Power = new Text("", 26, GameState.Project.Offices[OfficeCore.Office ?? "Office"].TextFont ?? "LCD Solid", Raylib.WHITE);
+        GameCache.HudCache.Usage = new Text("", 26, GameState.Project.Offices[OfficeCore.Office ?? "Office"].TextFont ?? "LCD Solid", Raylib.WHITE);
+        GameCache.HudCache.Time = new Text("", 26, GameState.Project.Offices[OfficeCore.Office ?? "Office"].TextFont ?? "LCD Solid", Raylib.WHITE);
+        GameCache.HudCache.Night = new Text("", 22, GameState.Project.Offices[OfficeCore.Office ?? "Office"].TextFont ?? "LCD Solid", Raylib.WHITE);
 
         GameCache.HudCache.CameraAnim.Reset();
         GameCache.HudCache.MaskAnim.Reset();
@@ -166,7 +159,7 @@ public class OfficeUtils
         GameCache.HudCache.CameraAnim.OnFinish(() =>
         {
             // this executes the first time we play an animation
-            // for some reason and it causes a single frame of
+            // for some reason, and it causes a single frame of
             // office to appear when opening the camera panel
             GameCache.HudCache.CameraAnim.Hide();
             GameCache.HudCache.CameraAnim.Reverse();
@@ -185,7 +178,7 @@ public class OfficeUtils
         GameCache.HudCache.MaskAnim.Hide();
     }
 
-    public static void DrawHUD()
+    public static void DrawHud()
     {
         if (OfficeCore.Office == null || OfficeCore.OfficeState == null)
         {
@@ -199,28 +192,28 @@ public class OfficeUtils
 
 
         GameCache.HudCache.Power.Content = $"Power Left: {OfficeCore.OfficeState.Power.Level}%";
-        GameCache.HudCache.Power.Draw(new(38, 601));
+        GameCache.HudCache.Power.Draw(new Vector2(38, 601));
 
         GameCache.HudCache.Usage.Content = $"Usage: ";
-        GameCache.HudCache.Usage.Draw(new(38, 637));
+        GameCache.HudCache.Usage.Draw(new Vector2(38, 637));
         Raylib.DrawTexture(Cache.GetTexture($"e.usage_{Math.Clamp(OfficeCore.OfficeState.Power.Usage, 0, 4) + 1}"), 136, 634, Raylib.WHITE);
 
 
         var minutes = TimeManager.GetTime().hours;
         GameCache.HudCache.Time.Content = $"{(minutes == 0 ? " 12" : minutes)} AM";
-        GameCache.HudCache.Time.Draw(new(minutes == 0 ? 1160 : 1165, 10));
+        GameCache.HudCache.Time.Draw(new Vector2(minutes == 0 ? 1160 : 1165, 10));
 
         GameCache.HudCache.Night.Content = $"Night {OfficeCore.OfficeState.Night}";
-        GameCache.HudCache.Night.Draw(new(1160, 45));
+        GameCache.HudCache.Night.Draw(new Vector2(1160, 45));
 
-        DrawUIButtons();
+        DrawUiButtons();
 
         if (OfficeCore.OfficeState.Settings.Toxic)
         {
             var player = OfficeCore.OfficeState.Player;
             player.ToxicLevel = Math.Clamp(player.ToxicLevel + (player.IsMaskOn ? 50 : -50) * Raylib.GetFrameTime(), 0, 280);
 
-            if (player.IsMaskOn && player.ToxicLevel >= 280 && player.MaskEnabled)
+            if (player is { IsMaskOn: true, ToxicLevel: >= 280, MaskEnabled: true })
             {
                 player.MaskEnabled = false;
                 ToggleMask();
@@ -229,7 +222,7 @@ public class OfficeUtils
 
             if (player.IsMaskOn || player.ToxicLevel > 0)
             {
-                float toxicLevel = player.ToxicLevel / 280f;
+                var toxicLevel = player.ToxicLevel / 280f;
                 Color color = new((int)(toxicLevel * 255), (int)((1 - toxicLevel) * 255), 0, 255);
                 Raylib.DrawTexture(Cache.GetTexture("e.toxic"), 25, 24, Raylib.WHITE);
                 Raylib.DrawRectangle(30, 47, (int)Math.Clamp(toxicLevel * 114, 0, 114), 20, color);
@@ -238,75 +231,79 @@ public class OfficeUtils
             player.MaskEnabled |= player.ToxicLevel <= 0;
         }
 
-        if (GameState.DebugMode)
+        if (!GameState.DebugMode) return;
+        Raylib.DrawText("Time", 44 + 950, 88 - 88, 22, Raylib.WHITE);
+        Raylib.DrawText("Seconds: " + TimeManager.GetTime().seconds, 88 + 950, 110 - 88, 22, Raylib.WHITE);
+        Raylib.DrawText("Minutes: " + TimeManager.GetTime().minutes, 88 + 950, 132 - 88, 22, Raylib.WHITE);
+
+        Raylib.DrawText("Animatronics", 44 + 950, 176 - 88, 22, Raylib.WHITE);
+        var i = 0;
+        var posY = 0;
+        foreach (var anim in OfficeCore.OfficeState.Animatronics)
         {
-            Raylib.DrawText("Time", 44 + 950, 88 - 88, 22, Raylib.WHITE);
-            Raylib.DrawText("Seconds: " + TimeManager.GetTime().seconds, 88 + 950, 110 - 88, 22, Raylib.WHITE);
-            Raylib.DrawText("Minutes: " + TimeManager.GetTime().minutes, 88 + 950, 132 - 88, 22, Raylib.WHITE);
+            i++;
+            posY = 176 + 22 * i;
+            Raylib.DrawText(anim.Value.Name, 88 + 950, posY - 88, 22, Raylib.WHITE);
+        }
 
-            Raylib.DrawText("Animatronics", 44 + 950, 176 - 88, 22, Raylib.WHITE);
-            var i = 0;
-            var posY = 0;
-            foreach (var anim in OfficeCore.OfficeState.Animatronics)
-            {
-                i++;
-                posY = 176 + 22 * i;
-                Raylib.DrawText(anim.Value.Name, 88 + 950, posY - 88, 22, Raylib.WHITE);
-            }
-
-            Raylib.DrawText("Cameras", 44 + 950, posY + 44 - 88, 22, Raylib.WHITE);
-            var i2 = 0;
-            foreach (var cam in OfficeCore.OfficeState.Cameras)
-            {
-                i2++;
-                var camPosY = posY + 44 + 22 * i2;
-                Raylib.DrawText(cam.Key, 88 + 950, camPosY - 88, 22, Raylib.WHITE);
-            }
+        Raylib.DrawText("Cameras", 44 + 950, posY + 44 - 88, 22, Raylib.WHITE);
+        var i2 = 0;
+        foreach (var cam in OfficeCore.OfficeState.Cameras)
+        {
+            i2++;
+            var camPosY = posY + 44 + 22 * i2;
+            Raylib.DrawText(cam.Key, 88 + 950, camPosY - 88, 22, Raylib.WHITE);
         }
     }
 
-    public static void DrawUIButtons()
+    private static void DrawUiButtons()
     {
         if (OfficeCore.OfficeState == null) return;
 
-        foreach (var UIButton in OfficeCore.OfficeState.UIButtons)
+        foreach (var (id, value) in OfficeCore.OfficeState.UIButtons)
         {
-            if (UIButton.Value.Input?.Position == null) continue;
+            if (value.Input?.Position == null) continue;
 
-            Vector2 position = new((int)(UIButton.Value.Input.Position[0] * Globals.xMagic),
-                (int)(UIButton.Value.Input.Position[1] * Globals.yMagic));
+            Vector2 position = new(
+                (int)(value.Input.Position[0] * Globals.XMagic),
+                (int)(value.Input.Position[1] * Globals.YMagic)
+            );
 
-            if (!GameCache.Buttons.TryGetValue(UIButton.Key, out var button))
+            if (!GameCache.Buttons.TryGetValue(id, out var button))
             {
-                lock (GameState.buttonsLock)
+                lock (GameState.ButtonsLock)
                 {
-                    button = new Button2D(position, id: UIButton.Key, IsMovable: false,
-                    texture: Cache.GetTexture(UIButton.Value.Input.Image)
-                );
+                    var texture = Cache.GetTexture(value.Input.Image);
 
-                    button.OnUnHover(() =>
-                    {
-                        if (button.ID == "camera")
-                        {
-                            OfficeCore.OfficeState.Player.IsCameraUp = GameCache.HudCache.CameraAnim.State == AnimationState.Normal;
-                            GameCache.HudCache.CameraAnim.Show();
-                        }
-                        else if (button.ID == "mask")
-                        {
-                            ToggleMask();
-                        }
-                    });
+                    button = new Button2D(position, id: id, isMovable: false, texture: texture);
 
-                    GameCache.Buttons[UIButton.Key] = button;
+                    button.OnUnHover(() => HandleUnHover(id));
+
+                    GameCache.Buttons[id] = button;
                 }
             }
 
-            // This single expression reduced the total CPU time
-            // by 1 ms (huge performance, atleast 100 FPS more)
-            button.IsVisible = (UIButton.Key == "camera") ?
-                (!OfficeCore.OfficeState.Player.IsMaskOn && OfficeCore.OfficeState.Player.CameraEnabled) :
-                UIButton.Key != "mask" || (!OfficeCore.OfficeState.Player.IsCameraUp && OfficeCore.OfficeState.Player.MaskEnabled); ;
+            button.IsVisible = (id == "camera")
+                ? (!OfficeCore.OfficeState.Player.IsMaskOn && OfficeCore.OfficeState.Player.CameraEnabled)
+                : id != "mask" || (!OfficeCore.OfficeState.Player.IsCameraUp && OfficeCore.OfficeState.Player.MaskEnabled);
+
             button.Draw(position);
+        }
+    }
+
+    private static void HandleUnHover(string id)
+    {
+        switch (id)
+        {
+            case "camera":
+                if (OfficeCore.OfficeState != null)
+                    OfficeCore.OfficeState.Player.IsCameraUp =
+                        GameCache.HudCache.CameraAnim.State == AnimationState.Normal;
+                GameCache.HudCache.CameraAnim.Show();
+                break;
+            case "mask":
+                ToggleMask();
+                break;
         }
     }
 }

--- a/FNaF Studio Runtime/Office/Scenes/CameraHandler.cs
+++ b/FNaF Studio Runtime/Office/Scenes/CameraHandler.cs
@@ -59,7 +59,7 @@ public class CameraHandler : IScene
                 }
                 else
                 {
-                    // TODO: Draw signal interrupted state
+                    Raylib.DrawTexture(Cache.GetTexture("e.signalinterrupted"), 470, 130, Raylib.WHITE);
                 }
             }
         foreach (var sprite in OfficeCore.OfficeState.CameraUI.Sprites.Values)

--- a/FNaF Studio Runtime/Office/Scenes/CameraHandler.cs
+++ b/FNaF Studio Runtime/Office/Scenes/CameraHandler.cs
@@ -7,16 +7,16 @@ using System.Numerics;
 namespace FNaFStudio_Runtime.Office.Scenes;
 public class CameraHandler : IScene
 {
-    public static float Direction = -1;
-    public static float timeSinceSwitch;
+    private static float _direction = -1;
+    private static float _timeSinceSwitch;
     public string Name => "CameraHandler";
     public SceneType Type => SceneType.Cameras;
 
     public void Update()
     {
-        float deltaTime = Raylib.GetFrameTime();
+        var deltaTime = Raylib.GetFrameTime();
 
-        foreach (var camera in OfficeCore.OfficeState.Cameras.Values)
+        foreach (var camera in OfficeCore.OfficeState?.Cameras.Values)
         {
             camera.Update(deltaTime);
         }
@@ -39,15 +39,15 @@ public class CameraHandler : IScene
                         scroll = curCam.Scroll * 30,
                         deltaTimeScaled = deltaTime * 100;
                     var velocity = Math.Clamp((int)Math.Abs(scroll - 640), 0, 640);
-                    timeSinceSwitch += deltaTimeScaled;
-                    if (timeSinceSwitch >= 500)
+                    _timeSinceSwitch += deltaTimeScaled;
+                    if (_timeSinceSwitch >= 500)
                     {
-                        if (GameState.ScrollX == maxScroll || GameState.ScrollX == 0)
+                        if (Math.Abs(GameState.ScrollX - maxScroll) >= maxScroll || GameState.ScrollX == 0)
                         {
-                            Direction = -Direction;
-                            timeSinceSwitch = 0;
+                            _direction = -_direction;
+                            _timeSinceSwitch = 0;
                         }
-                        GameState.ScrollX += Direction * (velocity < 320 ? 0.1f : velocity < 640 ? 0.3f : 0.5f) * deltaTimeScaled;
+                        GameState.ScrollX += _direction * (velocity < 320 ? 0.1f : velocity < 640 ? 0.3f : 0.5f) * deltaTimeScaled;
                     }
                     GameState.ScrollX = Math.Clamp(GameState.ScrollX, 0, maxScroll);
                     if (curCam.Panorama)
@@ -66,23 +66,33 @@ public class CameraHandler : IScene
         {
             if (!sprite.Visible || string.IsNullOrEmpty(sprite.Sprite))
                 continue;
-            var position = new Vector2(sprite.X * Globals.xMagic, sprite.Y * Globals.yMagic);
+            var position = new Vector2(sprite.X * Globals.XMagic, sprite.Y * Globals.YMagic);
             Raylib.DrawTextureEx(Cache.GetTexture(sprite.Sprite), position, 0, 1, Raylib.WHITE);
         }
-        foreach (var button in OfficeCore.OfficeState.CameraUI.Buttons)
+        foreach (var (key, button) in OfficeCore.OfficeState.CameraUI.Buttons)
         {
-            if (string.IsNullOrEmpty(button.Value.Sprite))
+            if (string.IsNullOrEmpty(button.Sprite))
                 continue;
-            string UID = $"{button.Key ?? ""}{button.Value.Sprite}";
-            Vector2 position = new(button.Value.X * Globals.xMagic, button.Value.Y * Globals.yMagic);
-            if (!GameCache.Buttons.TryGetValue(UID, out var cachedButton))
+
+            string uid = string.Concat(key, button.Sprite);
+
+            Vector2 position = new(button.X * Globals.XMagic, button.Y * Globals.YMagic);
+
+            if (!GameCache.Buttons.TryGetValue(uid, out var cachedButton))
             {
-                cachedButton = new Button2D(position, texture: Cache.GetTexture(button.Value.Sprite), IsMovable: false, id: UID);
-                if (!string.IsNullOrEmpty(button.Key)) cachedButton.OnClick(() => { OfficeCore.OfficeState.Player.SetCamera(button.Key); });
-                GameCache.Buttons[UID] = cachedButton;
+                var texture = Cache.GetTexture(button.Sprite);
+                cachedButton = new Button2D(position, texture: texture, isMovable: false, id: uid);
+
+                if (!string.IsNullOrEmpty(key))
+                {
+                    cachedButton.OnClick(() => OfficeCore.OfficeState.Player.SetCamera(key));
+                }
+                GameCache.Buttons[uid] = cachedButton;
             }
+
             cachedButton.Draw(position);
         }
-        OfficeUtils.DrawHUD();
+
+        OfficeUtils.DrawHud();
     }
 }

--- a/FNaF Studio Runtime/Util/CrashHandler.cs
+++ b/FNaF Studio Runtime/Util/CrashHandler.cs
@@ -10,8 +10,8 @@ namespace FNaFStudio_Runtime.Util;
 
 public class CrashHandler : IScene
 {
-    public static string title = "An error occurred during runtime execution";
-    public static string errorMessage = "";
+    private const string Title = "An error occurred during runtime execution";
+    public static string ErrorMessage = "";
     public string Name => "CrashHandler";
     public SceneType Type => SceneType.CrashHandler;
 
@@ -22,8 +22,8 @@ public class CrashHandler : IScene
     public void Draw()
     {
         Raylib.ClearBackground(RuntimeUtils.ParseStringToColor("89", "157", "220"));
-        Raylib.DrawTextEx(Cache.GetFont("Arial Bold", 20), title, new Vector2(64, 64), 26, 1, Raylib.WHITE);
-        Raylib.DrawTextEx(Cache.GetFont("Arial", 20), errorMessage, new Vector2(64, 128), 20, 1, Raylib.WHITE);
+        Raylib.DrawTextEx(Cache.GetFont("Arial Bold", 20), Title, new Vector2(64, 64), 26, 1, Raylib.WHITE);
+        Raylib.DrawTextEx(Cache.GetFont("Arial", 20), ErrorMessage, new Vector2(64, 128), 20, 1, Raylib.WHITE);
     }
 
     public static void GlobalExceptionHandler(object sender, UnhandledExceptionEventArgs e)
@@ -49,7 +49,7 @@ public class CrashHandler : IScene
             var stackTrace = new StackTrace(ex, true);
             var customStackTrace = new StringBuilder();
 
-            foreach (var frame in stackTrace.GetFrames()?.Where(IsRelevantFrame) ?? [])
+            foreach (var frame in stackTrace.GetFrames().Where(IsRelevantFrame))
             {
                 var frameType = frame.GetMethod()?.DeclaringType?.FullName ?? "UnknownClass";
                 var frameMethodName = frame.GetMethod()?.Name ?? "UnknownMethod";
@@ -73,7 +73,7 @@ public class CrashHandler : IScene
                method.DeclaringType.Assembly == Assembly.GetExecutingAssembly();
     }
 
-    public static void SafeBSOD()
+    public static void SafeBsod()
     {
         // Note: this will NOT create a new window
         RuntimeUtils.Scene.SetScene(SceneType.CrashHandler);
@@ -98,7 +98,7 @@ public static class TaskExtensions
         catch (Exception ex)
         {
             CrashHandler.LogException(ex);
-            CrashHandler.SafeBSOD();
+            CrashHandler.SafeBsod();
         }
     }
 }

--- a/FNaF Studio Runtime/Util/Logger.cs
+++ b/FNaF Studio Runtime/Util/Logger.cs
@@ -9,14 +9,14 @@ public static class Logger
 {
     public enum LogLevel
     {
-        INFO,
-        WARN,
-        ERROR,
-        FATAL,
-        DEBUG
+        Info,
+        Warn,
+        Error,
+        Fatal,
+        Debug
     }
 
-    private static readonly string[] SPLASH =
+    private static readonly string[] Splash =
     [
         @" __________________      _____  ___________ ___________ _______    ________.___ _______ ___________    ",
         @"\_   _____/\      \    /  _  \ \_   _____/ \_   _____/ \      \  /  _____/|   |\      \ \_   _____/    ",
@@ -32,9 +32,9 @@ public static class Logger
         @"                                                     \/         \/                                     "
     ]; // don't log that
 
-    private static readonly SemaphoreSlim semaphore = new(1, 1);
+    private static readonly SemaphoreSlim Semaphore = new(1, 1);
 
-    private static readonly ConsoleColor[] colors =
+    private static readonly ConsoleColor[] Colors =
     [
         ConsoleColor.Cyan, ConsoleColor.DarkYellow, ConsoleColor.Red, ConsoleColor.DarkRed, ConsoleColor.Yellow
     ];
@@ -52,29 +52,29 @@ public static class Logger
 
         var newLogLevel = (TraceLogLevel)logLevel switch
         {
-            TraceLogLevel.LOG_ALL => LogLevel.INFO,
-            TraceLogLevel.LOG_TRACE => LogLevel.WARN,
-            TraceLogLevel.LOG_DEBUG => LogLevel.WARN,
-            TraceLogLevel.LOG_INFO => LogLevel.INFO,
-            TraceLogLevel.LOG_WARNING => LogLevel.WARN,
-            TraceLogLevel.LOG_ERROR => LogLevel.ERROR,
-            TraceLogLevel.LOG_FATAL => LogLevel.FATAL,
-            TraceLogLevel.LOG_NONE => LogLevel.INFO,
+            TraceLogLevel.LOG_ALL => LogLevel.Info,
+            TraceLogLevel.LOG_TRACE => LogLevel.Warn,
+            TraceLogLevel.LOG_DEBUG => LogLevel.Warn,
+            TraceLogLevel.LOG_INFO => LogLevel.Info,
+            TraceLogLevel.LOG_WARNING => LogLevel.Warn,
+            TraceLogLevel.LOG_ERROR => LogLevel.Error,
+            TraceLogLevel.LOG_FATAL => LogLevel.Fatal,
+            TraceLogLevel.LOG_NONE => LogLevel.Info,
             _ => throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, null)
         };
 
         LogCustomAsync(newLogLevel, "Raylib", RuntimeUtils.SBytePointerToString(text)).Wait();
     }
 
-    public static async Task LogCustomAsync(LogLevel logLevel, string module, string message, bool tofiles = true)
+    private static async Task LogCustomAsync(LogLevel logLevel, string module, string message, bool tofiles = true)
     {
-        await semaphore.WaitAsync();
+        await Semaphore.WaitAsync();
         try
         {
             var timestamp = DateTime.Now.ToString("HH:mm:ss");
             Console.ForegroundColor = ConsoleColor.White;
             Console.Write($"{timestamp} ");
-            Console.ForegroundColor = colors[(int)logLevel];
+            Console.ForegroundColor = Colors[(int)logLevel];
             Console.Write($"{logLevel} ");
             Console.ForegroundColor = ConsoleColor.White;
             Console.Write("(");
@@ -85,56 +85,56 @@ public static class Logger
 
             if (tofiles)
             {
-                using StreamWriter writer = new("engine.log", true);
+                await using StreamWriter writer = new("engine.log", true);
                 await writer.WriteLineAsync($"{timestamp} {logLevel} ({module}): {message}");
             }
         }
         finally
         {
-            semaphore.Release();
+            Semaphore.Release();
         }
 
-        if (logLevel == LogLevel.FATAL)
+        if (logLevel == LogLevel.Fatal)
         {
-            CrashHandler.errorMessage = message;
+            CrashHandler.ErrorMessage = message;
             RuntimeUtils.Scene.SetScene(SceneType.CrashHandler);
         }
     }
 
     public static async Task<bool> LineAsync(string module, string message)
     {
-        await LogCustomAsync(LogLevel.INFO, module, message);
+        await LogCustomAsync(LogLevel.Info, module, message);
         return true;
     }
 
     public static Task LogAsync(string module, string message)
     {
-        return LogCustomAsync(LogLevel.INFO, module, message);
+        return LogCustomAsync(LogLevel.Info, module, message);
     }
 
     public static Task LogErrorAsync(string module, string message)
     {
-        return LogCustomAsync(LogLevel.ERROR, module, message);
+        return LogCustomAsync(LogLevel.Error, module, message);
     }
 
     public static Task LogFatalAsync(string module, string message)
     {
-        return LogCustomAsync(LogLevel.FATAL, module, message);
+        return LogCustomAsync(LogLevel.Fatal, module, message);
     }
 
     public static Task LogWarnAsync(string module, string message)
     {
-        return LogCustomAsync(LogLevel.WARN, module, message);
+        return LogCustomAsync(LogLevel.Warn, module, message);
     }
 
     public static async Task DrawSplashAsync()
     {
-        await semaphore.WaitAsync();
+        await Semaphore.WaitAsync();
         try
         {
-            using StreamWriter writer = new("engine.log", true);
+            await using StreamWriter writer = new("engine.log", true);
             Console.Clear();
-            foreach (var line in SPLASH)
+            foreach (var line in Splash)
             {
                 Console.WriteLine(line);
                 await writer.WriteLineAsync(line);
@@ -142,7 +142,7 @@ public static class Logger
         }
         finally
         {
-            semaphore.Release();
+            Semaphore.Release();
         }
     }
 }

--- a/FNaF Studio Runtime/Util/RuntimeUtils.cs
+++ b/FNaF Studio Runtime/Util/RuntimeUtils.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel.Design;
-using System.Text;
+﻿using System.Text;
 using FNaFStudio_Runtime.Data;
 using FNaFStudio_Runtime.Data.Definitions;
 using FNaFStudio_Runtime.Menus;
@@ -92,8 +91,7 @@ public static class RuntimeUtils
         return new GameJson.Input
         {
             Image =
-                (GameState.Project.Offices[OfficeCore.Office].OldUIButtons ?? new GameJson.Uibuttons()).Camera.Image ??
-                "",
+                (GameState.Project.Offices[OfficeCore.Office].OldUIButtons ?? new GameJson.Uibuttons()).Camera.Image,
             Position = (GameState.Project.Offices[OfficeCore.Office].OldUIButtons ?? new GameJson.Uibuttons()).Camera
                 .Position
         };
@@ -110,28 +108,27 @@ public static class RuntimeUtils
         return new GameJson.Input
         {
             Image =
-                (GameState.Project.Offices[OfficeCore.Office].OldUIButtons ?? new GameJson.Uibuttons()).Mask.Image ??
-                "",
+                (GameState.Project.Offices[OfficeCore.Office].OldUIButtons ?? new GameJson.Uibuttons()).Mask.Image,
             Position = (GameState.Project.Offices[OfficeCore.Office].OldUIButtons ?? new GameJson.Uibuttons()).Mask
                 .Position
         };
     }
 
-    public static GameJson.Input DeepCopyInput(GameJson.Input OrgInput)
+    public static GameJson.Input DeepCopyInput(GameJson.Input orgInput)
     {
         return new GameJson.Input
         {
-            Image = OrgInput.Image,
-            Position = OrgInput.Position
+            Image = orgInput.Image,
+            Position = orgInput.Position
         };
     }
 
-    public static GameJson.UI DeepCopyUI(GameJson.UI OrgUI)
+    public static GameJson.UI DeepCopyUi(GameJson.UI orgUi)
     {
         return new GameJson.UI
         {
-            IsToxic = OrgUI.IsToxic,
-            Text = OrgUI.Text
+            IsToxic = orgUi.IsToxic,
+            Text = orgUi.Text
         };
     }
 
@@ -151,21 +148,12 @@ public static class RuntimeUtils
             if ((int)idx < 0 || (int)idx >= GameState.Scenes.Count || GameState.Scenes[(int)idx] == null)
                 throw new InvalidOperationException("Invalid scene index or scene is null.");
 
-            if (GameState.CurrentScene != null)
-            {
-                GameState.ScrollXCache[(int)GameState.CurrentScene.Type] = GameState.ScrollX;
-                GameCache.TextStorage[GameState.CurrentScene.Name] = GameCache.Texts;
-                GameCache.ButtonStorage[GameState.CurrentScene.Name] = GameCache.Buttons;
-            }
+            GameState.ScrollXCache[(int)GameState.CurrentScene.Type] = GameState.ScrollX;
+            GameCache.TextStorage[GameState.CurrentScene.Name] = GameCache.Texts;
+            GameCache.ButtonStorage[GameState.CurrentScene.Name] = GameCache.Buttons;
             GameState.CurrentScene = GameState.Scenes[(int)idx];
-            if (GameCache.ButtonStorage.TryGetValue(GameState.CurrentScene.Name, out var Buttons))
-                GameCache.Buttons = Buttons;
-            else
-                GameCache.Buttons = [];
-            if (GameCache.TextStorage.TryGetValue(GameState.CurrentScene.Name, out var Texts))
-                GameCache.Texts = Texts;
-            else
-                GameCache.Texts = [];
+            GameCache.Buttons = GameCache.ButtonStorage.TryGetValue(GameState.CurrentScene.Name, out var buttons) ? buttons : [];
+            GameCache.Texts = GameCache.TextStorage.TryGetValue(GameState.CurrentScene.Name, out var texts) ? texts : [];
 
             GameState.ScrollX = GameState.ScrollXCache[(int)GameState.CurrentScene.Type];
             GameState.CurrentScene.Init();
@@ -173,25 +161,16 @@ public static class RuntimeUtils
 
         public static void SetScene(SceneType idx)
         {
-            GameState.CurrentScene?.Exit();
+            GameState.CurrentScene.Exit();
             if ((int)idx < 0 || (int)idx >= GameState.Scenes.Count || GameState.Scenes[(int)idx] == null)
                 throw new InvalidOperationException("Invalid scene index or scene is null.");
 
-            if (GameState.CurrentScene != null)
-            {
-                GameState.ScrollXCache[(int)GameState.CurrentScene.Type] = GameState.ScrollX;
-                GameCache.TextStorage[GameState.CurrentScene.Name] = GameCache.Texts;
-                GameCache.ButtonStorage[GameState.CurrentScene.Name] = GameCache.Buttons;
-            }
+            GameState.ScrollXCache[(int)GameState.CurrentScene.Type] = GameState.ScrollX;
+            GameCache.TextStorage[GameState.CurrentScene.Name] = GameCache.Texts;
+            GameCache.ButtonStorage[GameState.CurrentScene.Name] = GameCache.Buttons;
             GameState.CurrentScene = GameState.Scenes[(int)idx];
-            if (GameCache.ButtonStorage.TryGetValue(GameState.CurrentScene.Name, out var Buttons))
-                GameCache.Buttons = Buttons;
-            else
-                GameCache.Buttons = [];
-            if (GameCache.TextStorage.TryGetValue(GameState.CurrentScene.Name, out var Texts))
-                GameCache.Texts = Texts;
-            else
-                GameCache.Texts = [];
+            GameCache.Buttons = GameCache.ButtonStorage.TryGetValue(GameState.CurrentScene.Name, out var buttons) ? buttons : [];
+            GameCache.Texts = GameCache.TextStorage.TryGetValue(GameState.CurrentScene.Name, out var texts) ? texts : [];
 
             GameState.ScrollX = GameState.ScrollXCache[(int)GameState.CurrentScene.Type];
             GameState.CurrentScene.Init();


### PR DESCRIPTION
* Re-linted and reformatted runtime code for consistency (Re-lint also fixed all of the warnings).
* Fixed useless mass allocations in `GetExpr`, `TriggerEvent`, `TickEvents`, and `DrawUiButtons`.
* Added "Signal Interrupted" as `e.signalinterrupted` texture for cameras.
